### PR TITLE
Core: option to allocate elastic ip for bootnode and validator

### DIFF
--- a/bootnode.yml
+++ b/bootnode.yml
@@ -84,3 +84,22 @@
   tasks:
     - name: restart machine after setup
       shell: shutdown -r 1
+
+- name: Create bootnode elastic ip
+  hosts: localhost
+  gather_facts: False
+  tasks:
+    - name: associate elastic ip for bootnode
+      ec2_eip:
+        ec2_access_key: "{{ access_key }}"
+        ec2_secret_key: "{{ secret_key }}"
+        region: "{{ region }}"
+        reuse_existing_ip_allowed: yes
+        state: present
+        in_vpc: yes
+        device_id: "{{ ec2.instance_ids[0] }}"
+      register: instance_elastic_ip
+      when: associate_bootnode_elastic_ip == true
+
+    - debug: var=instance_elastic_ip.public_ip
+      when: associate_bootnode_elastic_ip == true

--- a/group_vars/all.example
+++ b/group_vars/all.example
@@ -82,6 +82,7 @@ explorer_security_group: "explorer-security"
 allow_bootnode_ssh: true
 allow_bootnode_p2p: true
 allow_bootnode_rpc: true
+associate_bootnode_elastic_ip: false
 
 allow_explorer_ssh: true
 allow_explorer_p2p: true
@@ -95,3 +96,4 @@ allow_netstat_http: true
 
 allow_validator_ssh: true
 allow_validator_p2p: true
+associate_validator_elastic_ip: false

--- a/group_vars/all.network
+++ b/group_vars/all.network
@@ -66,6 +66,7 @@ explorer_security_group: "explorer-security"
 allow_bootnode_ssh: true
 allow_bootnode_p2p: true
 allow_bootnode_rpc: true
+associate_bootnode_elastic_ip: false
 
 allow_explorer_ssh: true
 allow_explorer_p2p: true
@@ -79,5 +80,6 @@ allow_netstat_http: true
 
 allow_validator_ssh: true
 allow_validator_p2p: true
+associate_validator_elastic_ip: false
 
 ################################################################

--- a/validator.yml
+++ b/validator.yml
@@ -82,3 +82,22 @@
   tasks:
     - name: restart machine after setup
       shell: shutdown -r 1
+
+- name: Create validator elastic ip
+  hosts: localhost
+  gather_facts: False
+  tasks:
+    - name: associate elastic ip for validator
+      ec2_eip:
+        ec2_access_key: "{{ access_key }}"
+        ec2_secret_key: "{{ secret_key }}"
+        region: "{{ region }}"
+        reuse_existing_ip_allowed: yes
+        state: present
+        in_vpc: yes
+        device_id: "{{ ec2.instance_ids[0] }}"
+      register: instance_elastic_ip
+      when: associate_validator_elastic_ip == true
+
+    - debug: var=instance_elastic_ip.public_ip
+      when: associate_validator_elastic_ip == true


### PR DESCRIPTION
Add option to allocate elastic ip for bootnode and validator.